### PR TITLE
1 remove explicitdirect pit instruction

### DIFF
--- a/PILT.js
+++ b/PILT.js
@@ -292,8 +292,8 @@ const pavlovian_images_f = () => {
         0.01: "PIT3.png",
         1.0: "PIT1.png",
         0.5: "PIT2.png",
-        "-0.01": "PIT6.png",
-        "-1": "PIT4.png",
+        "-0.01": "PIT4.png",
+        "-1": "PIT6.png",
         "-0.5": "PIT5.png"
     };
     PIT_imgs = Object.fromEntries(Object.entries(PIT_imgs).map(([k, v]) => [k, "Pav_stims/session" + sessionNum + "/" + v]));

--- a/PIT.js
+++ b/PIT.js
@@ -16,7 +16,7 @@ function generatePITstimulus(coin, ratio) {
   const ratio_index = experimentConfig.ratios.indexOf(ratio);
   // Calculate saturation based on ratio
   const ratio_factor = ratio_index / (experimentConfig.ratios.length - 1);
-  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%);`;
+  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%) brightness(${115 * (90/115) ** ratio_factor}%);`;
   const cloud_style = `filter: brightness(0.8) contrast(1.2);`;
   let PIT_imgs = {
     0.01: "PIT3.png",

--- a/PIT.js
+++ b/PIT.js
@@ -163,7 +163,7 @@ function getSelectedPITtrial() {
   const raw_data = jsPsych.data.get().filterCustom((trial) => trial.trialphase == "pit_trial");
   const trial_rewards = raw_data.select('trial_reward').values;
   // Select a random trial to be the bonus round with weights based on the rewards
-  const selected_trial = jsPsych.randomization.sampleWithReplacement(raw_data.values(), 1, trial_rewards.map(reward => logNormalPDF(reward, Math.log(40), 0.3)));
+  const selected_trial = jsPsych.randomization.sampleWithReplacement(raw_data.values(), 1, trial_rewards.map(reward => logNormalPDF(reward+1, Math.log(40), 0.3)));
   // Side effect: Save the reward for the bonus round
   window.sampledPITreward = selected_trial[0].trial_reward;
   // Return the trial index for referencing and the trial number for display

--- a/PIT.js
+++ b/PIT.js
@@ -289,30 +289,6 @@ const PITruleInstruction_2 = {
                 </div>
           </div>
     </div>
-    `, `
-    <div id="instruction-text" style="text-align: left">
-          <p><span class="highlight">Each time you see one of the backgrounds shown below, a coin will be added or removed in addition to your bonus for that round.</span></p>
-          <p>If a round is selected at the end of the game, the adjusted bonus from that round will be paid.</p>
-
-          <div class="pav-stimuli-container">
-                <div class="pit-pav-row">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT1.png"} class="pit-pav-icon">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT2.png"} class="pit-pav-icon">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT3.png"} class="pit-pav-icon">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT4.png"} class="pit-pav-icon">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT5.png"} class="pit-pav-icon">
-                      <img src=${"imgs/Pav_stims/session" + sessionNum + "/PIT6.png"} class="pit-pav-icon">
-                </div>
-                <div class="pit-coin-row">
-                      <img src="imgs/1pound.png" class="pit-coin-icon">
-                      <img src="imgs/50pence.png" class="pit-coin-icon">
-                      <img src="imgs/1penny.png" class="pit-coin-icon">
-                      <img src="imgs/1poundbroken.png" class="pit-coin-icon">
-                      <img src="imgs/50pencebroken.png" class="pit-coin-icon">
-                      <img src="imgs/1pennybroken.png" class="pit-coin-icon">
-                </div>
-          </div>
-    </div>
     `],
   simulation_options: {
     simulate: false

--- a/PIT.js
+++ b/PIT.js
@@ -271,7 +271,7 @@ const PITruleInstruction_2 = {
       <p><strong>But this time, you'll play in a cloudy place.</strong></p>
       <img src="imgs/occluding_clouds.png" style="height:12em">
       <p><span class="highlight">Coins will drop and be collected as usual, but they'll be hidden behind clouds.<br>You won't see them during the game.</span></p>
-      <p>We will also pay you the total amount of coins from a randomly selected piggy bank at the end of this game.</p>
+      <p>We will also pay you the bonus in the same way as in the previous game at the end.</p>
     </div>`,
     `
     <div id="instruction-text" style="text-align: left">

--- a/plugin-PILT.js
+++ b/plugin-PILT.js
@@ -115,8 +115,8 @@ jsPsychPILT = (function (jspsych) {
                     0.01: "PIT3.png",
                     1.0: "PIT1.png",
                     0.5: "PIT2.png",
-                    "-0.01": "PIT6.png",
-                    "-1": "PIT4.png",
+                    "-0.01": "PIT4.png",
+                    "-1": "PIT6.png",
                     "-0.5": "PIT5.png"
                 },
             }

--- a/post-vigour-test.js
+++ b/post-vigour-test.js
@@ -25,7 +25,7 @@ function generateComparisonStimulus(left, right) {
 function generatePiggyHTML(magnitude, ratio, side) {
   const ratio_index = comparisonConfig.ratios.indexOf(ratio);
   const ratio_factor = ratio_index / (comparisonConfig.ratios.length - 1);
-  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%);`;
+  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%) brightness(${115 * (90/115) ** ratio_factor}%);`;
 
   return `
       <img id="piggy-bank-${side}" src="imgs/piggy-bank.png" alt="Piggy Bank" style="${piggy_style}">
@@ -60,7 +60,7 @@ function updateDualPiggyTails(magnitude, ratio, side) {
       // Position each tail
       tail.style.left = `calc(50% + ${piggyBankWidth / 2 + (tailWidth + spacing) * i}px - ${tailWidth / 20}px)`;
       tail.style.width = `${tailWidth}px`;
-      tail.style.filter = `saturate(${50 * (400 / 50) ** ratio_factor}%)`;
+      tail.style.filter = `saturate(${50 * (400 / 50) ** ratio_factor}%) brightness(${115 * (90/115) ** ratio_factor}%)`;
 
       piggyContainer.appendChild(tail);
     }

--- a/vigour.html
+++ b/vigour.html
@@ -64,6 +64,7 @@
     preload,
     vigourInstructions,
     ...experimentTimeline,
+    vigour_bonus
   ];
 
   // Run or simulate the experiment

--- a/vigour.html
+++ b/vigour.html
@@ -41,6 +41,7 @@
 
 <body>
   <div id='display_element' class='jsPsychDE'></div>
+  <div id="persist-coin-container"></div>
 </body>
 <script>
   // Add the comparison task to the main experiment timeline

--- a/vigour.js
+++ b/vigour.js
@@ -381,7 +381,7 @@ function getSelectedTrial() {
   const raw_data = jsPsych.data.get().filterCustom((trial) => trial.trialphase == "vigour_trial");
   const trial_rewards = raw_data.select('trial_reward').values;
   // Select a random trial to be the bonus round with weights based on the rewards
-  const selected_trial = jsPsych.randomization.sampleWithReplacement(raw_data.values(), 1, trial_rewards.map(reward => logNormalPDF(reward, Math.log(40), 0.3)));
+  const selected_trial = jsPsych.randomization.sampleWithReplacement(raw_data.values(), 1, trial_rewards.map(reward => logNormalPDF(reward+1, Math.log(40), 0.3)));
   // Side effect: Save the reward for the bonus round
   window.sampledVigourReward = selected_trial[0].trial_reward;
   // Return the trial index for referencing and the trial number for display

--- a/vigour.js
+++ b/vigour.js
@@ -142,7 +142,7 @@ function updatePiggyTails(magnitude, ratio) {
       // Position each tail
       tail.style.left = `calc(50% + ${piggyBankWidth / 2 + (tailWidth + spacing) * i}px - ${tailWidth / 20}px)`;
       tail.style.width = `${tailWidth}px`;
-      tail.style.filter = `saturate(${50 * (400 / 50) ** ratio_factor}%)`;
+      tail.style.filter = `saturate(${50 * (400 / 50) ** ratio_factor}%) brightness(${115 * (90/115) ** ratio_factor}%)`;
 
       piggyContainer.appendChild(tail);
     }
@@ -159,7 +159,7 @@ function generateTrialStimulus(magnitude, ratio) {
   const ratio_index = experimentConfig.ratios.indexOf(ratio);
   // Calculate saturation based on ratio
   const ratio_factor = ratio_index / (experimentConfig.ratios.length - 1);
-  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%);`;
+  const piggy_style = `filter: saturate(${50 * (400 / 50) ** ratio_factor}%) brightness(${115 * (90/115) ** ratio_factor}%);`;
   return `
     <div class="experiment-wrapper">
       <!-- Middle Row (Piggy Bank & Coins) -->

--- a/vigour_instructions.js
+++ b/vigour_instructions.js
@@ -104,7 +104,7 @@ const ruleInstruction = {
         </div>
     </div>
     
-    <p><span class="highlight">Your bonus</span>: We will pay you the total amount of coins from a randomly selected piggy bank at the end of the game.</p>
+    <p><span class="highlight">Your bonus</span>: At the end of the game, we will pay you a proportion of the total amount of coins collected across all the piggy banks.</p>
     </div>
       `]
 };


### PR DESCRIPTION
- Remove direct instruction
- Reverse negative Pavlovian stimulus ordering
- Change the instruction for bonuses in Vigour and PIT
- Manipulate brightness for fixed ratio levels to enhance distinction for colour-blindness
- Fix errors in randomised sampling of trial rewards as bonuses

Close #1 